### PR TITLE
Add padding on left on HTML Lists

### DIFF
--- a/src/assets/style/utils/layout.scss
+++ b/src/assets/style/utils/layout.scss
@@ -19,3 +19,15 @@
 .columns {
   margin: 0;
 }
+
+@media all and (min-width: 768px) { 
+  ol, ul {
+    padding-left: 1.75rem;
+  } 
+}
+
+@media not all and (min-width: 768px) { 
+  ol, ul {
+    padding-left: 1.25rem;
+  } 
+}


### PR DESCRIPTION
## Description

Introduced a padding on the left of `<ul>` and `<ol>` tags.

**Resolve**: #4 

## Screenshots

### Before

![image](https://github.com/DomeT99/astro-minimal/assets/36475130/b25c44ea-ea46-455a-bd85-3f95fa6c8b01)
![image](https://github.com/DomeT99/astro-minimal/assets/36475130/26b95723-7f79-4731-9e1b-55b0daef5f5d)


### After

![image](https://github.com/DomeT99/astro-minimal/assets/36475130/47672939-0ea8-4db1-bbce-693c5f8a012c)

![image](https://github.com/DomeT99/astro-minimal/assets/36475130/ece4fc69-8717-4162-bc19-636345a743b6)



